### PR TITLE
GP-5607 interim fix for smtp.server config

### DIFF
--- a/resources/config_example.yaml
+++ b/resources/config_example.yaml
@@ -112,8 +112,10 @@ default.properties:
     
     # the mail server for sending messages from the GenePattern server
     smtp.server: smtp.broadinstitute.org
-    # the email address for sending help requests via the 'contact us' link
-    contact.us.email: gp-help@broadinstitute.org
+    # the email recipient of help requests sent via the 'contact us' link
+    contact.us.email: "gp-help@broadinstitute.org"
+    # the from email address for messages sent to end users, such as from the 'forgot password' link  
+    smtp.from.email: "no-reply@genepattern.org"
 
     # Change the skin GenePattern uses
     display.skin: frozen

--- a/src/org/genepattern/server/util/EmailNotificationManager.java
+++ b/src/org/genepattern/server/util/EmailNotificationManager.java
@@ -20,6 +20,8 @@ import javax.mail.Transport;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 
+import org.genepattern.server.config.GpContext;
+import org.genepattern.server.config.ServerConfigurationFactory;
 import org.genepattern.server.database.HibernateUtil;
 import org.genepattern.server.webapp.DNSClient;
 import org.genepattern.server.webapp.jsf.UIBeanHelper;
@@ -104,7 +106,8 @@ public class EmailNotificationManager {
 		    continue;
 		}
 		String domain = to.substring(at + 1);
-		String mailServer = System.getProperty("smtp.server");
+		final String mailServer = ServerConfigurationFactory.instance().getGPProperty( GpContext.getServerContext(), 
+		        MailSender.PROP_SMTP_SERVER, MailSender.DEFAULT_SMTP_SERVER);
 		TreeMap<Integer, String> tmHosts = null;
 		if (mailServer == null) {
 		    tmHosts = dnsClient.findMXServers(domain);

--- a/src/org/genepattern/server/util/EmailNotificationManager.java
+++ b/src/org/genepattern/server/util/EmailNotificationManager.java
@@ -65,6 +65,17 @@ public class EmailNotificationManager {
 	threads.remove(aThread);
     }
 
+    protected static String getFromAddress() {
+        // old way, used System.gptProperty("fqHostName")
+        // interim way, GpConfig.getGPProperty(gpContext, "fqHostName")
+        //final String fqHostName=ServerConfigurationFactory.instance().getGPProperty(GpContext.getServerContext(), "fqHostName");
+        //final String from = "GenePattern@" + fqHostName; 
+        // newer way, uses PROP_SMTP_FROM_EMAIL
+        final String from = ServerConfigurationFactory.instance().getGPProperty(GpContext.getServerContext(), 
+                MailSender.PROP_SMTP_FROM_EMAIL, MailSender.DEFAULT_SMTP_FROM_EMAIL);
+        return from;
+    }
+    
     public void sendJobCompletionEmail(String email, String user, String jobId) {
 	String status = "status unknown";
 	String moduleName = "";
@@ -80,7 +91,7 @@ public class EmailNotificationManager {
 	}
 
 	String addresses = email;
-    String from = "GenePattern@" + System.getProperty("fqHostName");
+	final String from=getFromAddress();
 	String subject = "Job " + jobId + " - " + moduleName + " - " + status;
 	StringBuffer msg = new StringBuffer();
 	msg.append("The results for job " + jobId + ", " + moduleName + ", are available on the ");
@@ -235,7 +246,8 @@ class JobWaitThread extends Thread {
 
 	    EmailNotificationManager em = EmailNotificationManager.getInstance();
 	    String addresses = email;
-	    String from = "GenePattern@" + System.getProperty("fqHostName");
+	    //final String from = "GenePattern@" + System.getProperty("fqHostName");
+	    final String from=EmailNotificationManager.getFromAddress();
 	    String subject = "Job " + jobID + " - status unavailable";
 	    StringBuffer msg = new StringBuffer();
 	    msg.append("There was a problem getting the status for job " + jobID);

--- a/src/org/genepattern/server/util/MailSender.java
+++ b/src/org/genepattern/server/util/MailSender.java
@@ -1,0 +1,101 @@
+package org.genepattern.server.util;
+
+import java.util.Date;
+import java.util.Properties;
+
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+import org.apache.log4j.Logger;
+
+/**
+ * Generic java based mail sender class, based on the Contact Us Bean.
+ * Created as a generic replacement for both the ContactUsBean and the EmailNotificationManager.
+ * @author pcarr
+ *
+ */
+public class MailSender {
+    private static final Logger log = Logger.getLogger(MailSender.class);
+
+    final String smtpServer;
+    final String replyTo; // aka replyTo
+    final String sendToAddress;
+    final String subject;
+    final String message;
+    
+    private MailSender(Builder b) {
+        this.smtpServer=b.smtpServer;
+        this.replyTo=b.replyTo;
+        this.sendToAddress=b.sendToAddress;
+        this.subject=b.subject;
+        this.message=b.message;
+    }
+    
+    /**
+     * Send the message
+     * @throws Exception if there was a problem sending the message
+     */
+    public void sendMessage() throws Exception {
+        final Properties p = new Properties();
+        p.put("mail.host", smtpServer);
+
+        final Session mailSession = Session.getDefaultInstance(p, null);
+        mailSession.setDebug(false);
+        final MimeMessage msg = new MimeMessage(mailSession);
+
+        try {
+            msg.setSubject(subject);
+            msg.setText(message);
+            msg.setFrom(new InternetAddress(replyTo));
+            msg.setSentDate(new Date());
+            msg.addRecipient(Message.RecipientType.TO, new InternetAddress(sendToAddress));
+            Transport.send(msg);
+        } 
+        catch (MessagingException e) {
+            log.error(e);
+            throw e;
+        }
+    }
+    
+    public static final class Builder {
+        private String smtpServer;
+        private String replyTo; // aka replyTo
+        private String sendToAddress; // aka sendToAddress
+        private String subject;
+        private String message;
+        
+        public Builder smtpServer(final String smtpServer) {
+            this.smtpServer=smtpServer;
+            return this;
+        }
+        
+        public Builder replyTo(final String replyTo) {
+            this.replyTo=replyTo;
+            return this;
+        }
+        
+        public Builder sendToAddress(final String sendToAddress) {
+            this.sendToAddress=sendToAddress;
+            return this;
+        }
+        
+        public Builder subject(final String subject) {
+            this.subject=subject;
+            return this;
+        }
+        
+        public Builder message(final String message) {
+            this.message=message;
+            return this;
+        }
+        
+        public MailSender build() {
+            return new MailSender(this);
+        }
+    }
+
+}

--- a/src/org/genepattern/server/util/MailSender.java
+++ b/src/org/genepattern/server/util/MailSender.java
@@ -11,6 +11,9 @@ import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 
 import org.apache.log4j.Logger;
+import org.genepattern.server.config.GpConfig;
+import org.genepattern.server.config.GpContext;
+import org.genepattern.server.config.ServerConfigurationFactory;
 
 /**
  * Generic java based mail sender class, based on the Contact Us Bean.
@@ -21,12 +24,20 @@ import org.apache.log4j.Logger;
 public class MailSender {
     private static final Logger log = Logger.getLogger(MailSender.class);
 
-    final String smtpServer;
-    final String replyTo; // aka replyTo
-    final String sendToAddress;
-    final String subject;
-    final String message;
+    /**
+     * Set the 'smtp.server' property to change the mail.host that the javax.mail.Transport class uses to 
+     * send email messages.
+     */
+    public static final String PROP_SMTP_SERVER="smtp.server";
+    /** The default smtp.server=smtp.broadinstitute.org */
+    public static final String DEFAULT_SMTP_SERVER="smtp.broadinstitute.org";
     
+    private final String smtpServer;
+    private final String replyTo; // aka replyTo
+    private final String sendToAddress;
+    private final String subject;
+    private final String message;
+
     private MailSender(Builder b) {
         this.smtpServer=b.smtpServer;
         this.replyTo=b.replyTo;
@@ -68,6 +79,19 @@ public class MailSender {
         private String subject;
         private String message;
         
+        public Builder() {
+            this(ServerConfigurationFactory.instance(), 
+                 GpContext.getServerContext());
+        }
+        /**
+         * Pass in config objects to initialize default value for the 'smtp.server'
+         * @param gpConfig, the server configuration instance
+         * @param gpContext, the server context
+         */
+        public Builder(final GpConfig gpConfig, final GpContext gpContext) {
+            this.smtpServer = gpConfig.getGPProperty(gpContext, PROP_SMTP_SERVER, DEFAULT_SMTP_SERVER);
+        }
+        
         public Builder smtpServer(final String smtpServer) {
             this.smtpServer=smtpServer;
             return this;
@@ -97,5 +121,4 @@ public class MailSender {
             return new MailSender(this);
         }
     }
-
 }

--- a/src/org/genepattern/server/util/MailSender.java
+++ b/src/org/genepattern/server/util/MailSender.java
@@ -33,15 +33,15 @@ public class MailSender {
     public static final String DEFAULT_SMTP_SERVER="smtp.broadinstitute.org";
     
     private final String smtpServer;
-    private final String replyTo; // aka replyTo
-    private final String sendToAddress;
+    private final String from; // aka replyTo
+    private final String to; // aka sendToAddress
     private final String subject;
     private final String message;
 
     private MailSender(Builder b) {
         this.smtpServer=b.smtpServer;
-        this.replyTo=b.replyTo;
-        this.sendToAddress=b.sendToAddress;
+        this.from=b.from;
+        this.to=b.to;
         this.subject=b.subject;
         this.message=b.message;
     }
@@ -61,9 +61,9 @@ public class MailSender {
         try {
             msg.setSubject(subject);
             msg.setText(message);
-            msg.setFrom(new InternetAddress(replyTo));
+            msg.setFrom(new InternetAddress(from));
             msg.setSentDate(new Date());
-            msg.addRecipient(Message.RecipientType.TO, new InternetAddress(sendToAddress));
+            msg.addRecipient(Message.RecipientType.TO, new InternetAddress(to));
             Transport.send(msg);
         } 
         catch (MessagingException e) {
@@ -74,8 +74,8 @@ public class MailSender {
     
     public static final class Builder {
         private String smtpServer;
-        private String replyTo; // aka replyTo
-        private String sendToAddress; // aka sendToAddress
+        private String from; // aka replyTo
+        private String to;   // aka sendToAddress, aka recipient
         private String subject;
         private String message;
         
@@ -97,13 +97,13 @@ public class MailSender {
             return this;
         }
         
-        public Builder replyTo(final String replyTo) {
-            this.replyTo=replyTo;
+        public Builder from(final String from) {
+            this.from=from;
             return this;
         }
         
-        public Builder sendToAddress(final String sendToAddress) {
-            this.sendToAddress=sendToAddress;
+        public Builder to(final String to) {
+            this.to=to;
             return this;
         }
         

--- a/src/org/genepattern/server/util/MailSender.java
+++ b/src/org/genepattern/server/util/MailSender.java
@@ -32,6 +32,13 @@ public class MailSender {
     /** The default smtp.server=smtp.broadinstitute.org */
     public static final String DEFAULT_SMTP_SERVER="smtp.broadinstitute.org";
     
+    /** 
+     * Set the 'smtp.from.email' for notifications sent to end-users, such as from the 'forgot your password' link.
+     */
+    public static final String PROP_SMTP_FROM_EMAIL="smtp.from.email";
+    /** The default smtp.from.email=no-reply@genepattern.org */
+    public static final String DEFAULT_SMTP_FROM_EMAIL="no-reply@genepattern.org";
+    
     private final String smtpServer;
     private final String from; // aka replyTo
     private final String to; // aka sendToAddress
@@ -84,12 +91,13 @@ public class MailSender {
                  GpContext.getServerContext());
         }
         /**
-         * Pass in config objects to initialize default value for the 'smtp.server'
+         * Pass in config objects to initialize default values for the 'smtp.server'
          * @param gpConfig, the server configuration instance
          * @param gpContext, the server context
          */
         public Builder(final GpConfig gpConfig, final GpContext gpContext) {
             this.smtpServer = gpConfig.getGPProperty(gpContext, PROP_SMTP_SERVER, DEFAULT_SMTP_SERVER);
+            this.from = gpConfig.getGPProperty(gpContext, PROP_SMTP_FROM_EMAIL, DEFAULT_SMTP_FROM_EMAIL);
         }
         
         public Builder smtpServer(final String smtpServer) {

--- a/src/org/genepattern/server/webapp/jsf/ContactUsBean.java
+++ b/src/org/genepattern/server/webapp/jsf/ContactUsBean.java
@@ -91,9 +91,9 @@ public class ContactUsBean {
         final String contactUsEmail = gpConfig.getGPProperty(gpContext, PROP_CONTACT_EMAIL, DEFAULT_CONTACT_EMAIL);
         final MailSender m=new MailSender.Builder(gpConfig, gpContext)
             // set from
-            .replyTo(replyTo)
+            .from(replyTo)
             // set to
-            .sendToAddress(contactUsEmail)
+            .to(contactUsEmail)
             // set subject
             .subject(subject)
             // set message

--- a/src/org/genepattern/server/webapp/jsf/ContactUsBean.java
+++ b/src/org/genepattern/server/webapp/jsf/ContactUsBean.java
@@ -16,6 +16,7 @@ import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 
 import org.apache.log4j.Logger;
+import org.genepattern.server.config.GpConfig;
 import org.genepattern.server.config.GpContext;
 import org.genepattern.server.config.ServerConfigurationFactory;
 import org.genepattern.server.user.User;
@@ -40,9 +41,7 @@ import org.genepattern.server.util.MailSender;
 public class ContactUsBean {
     public static final String PROP_CONTACT_EMAIL="contact.us.email";
     public static final String DEFAULT_CONTACT_EMAIL="gp-help@broadinstitute.org";
-    public static final String PROP_SMTP_SERVER="smtp.server";
-    public static final String DEFAULT_SMTP_SERVER="smtp.broadinstitute.org"; 
-    
+
     private String subject;
 
     private String replyTo;
@@ -87,20 +86,14 @@ public class ContactUsBean {
     }
 
     public String send() {
+        final GpConfig gpConfig=ServerConfigurationFactory.instance();
         final GpContext gpContext=GpContext.getServerContext();
-        final String sendToAddress = ServerConfigurationFactory.instance().getGPProperty(gpContext, PROP_CONTACT_EMAIL, DEFAULT_CONTACT_EMAIL);
-        final String smtpServer = ServerConfigurationFactory.instance().getGPProperty(gpContext, PROP_SMTP_SERVER, DEFAULT_SMTP_SERVER);
-        return send(sendToAddress, smtpServer);
-    }
-    
-    public String send(final String sendToAddress, final String smtpServer) {
-        final MailSender m=new MailSender.Builder()
-            // set smtpServer
-            .smtpServer(smtpServer)
+        final String contactUsEmail = gpConfig.getGPProperty(gpContext, PROP_CONTACT_EMAIL, DEFAULT_CONTACT_EMAIL);
+        final MailSender m=new MailSender.Builder(gpConfig, gpContext)
             // set from
             .replyTo(replyTo)
             // set to
-            .sendToAddress(sendToAddress)
+            .sendToAddress(contactUsEmail)
             // set subject
             .subject(subject)
             // set message
@@ -110,7 +103,6 @@ public class ContactUsBean {
             m.sendMessage();
             this.sent=true;
             return "success";
-        
         }
         catch (Exception e) {
             UIBeanHelper.setErrorMessage("An error occurred while sending the email.");

--- a/src/org/genepattern/server/webapp/jsf/ForgotPasswordBean.java
+++ b/src/org/genepattern/server/webapp/jsf/ForgotPasswordBean.java
@@ -68,7 +68,6 @@ public class ForgotPasswordBean {
 
     protected void sendResetPasswordMessage(final String to, final String newPassword) throws Exception {
         final MailSender m = new MailSender.Builder()
-            .from("no-reply@genepattern.org")
             .to(to)
             .subject("Your GenePattern Password")
             .message("Your GenePattern password has been reset to "

--- a/src/org/genepattern/server/webapp/jsf/ForgotPasswordBean.java
+++ b/src/org/genepattern/server/webapp/jsf/ForgotPasswordBean.java
@@ -5,84 +5,19 @@
 package org.genepattern.server.webapp.jsf;
 
 import java.security.NoSuchAlgorithmException;
-import java.util.Date;
-import java.util.Properties;
-
-import javax.mail.Message;
-import javax.mail.MessagingException;
-import javax.mail.Session;
-import javax.mail.Transport;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
 
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.log4j.Logger;
 import org.genepattern.server.EncryptionUtil;
+import org.genepattern.server.database.HibernateUtil;
 import org.genepattern.server.user.User;
 import org.genepattern.server.user.UserDAO;
+import org.genepattern.server.util.MailSender;
 
 public class ForgotPasswordBean {
-
-    private String username;
-
     private static Logger log = Logger.getLogger(ForgotPasswordBean.class);
 
-    public String resetPassword() {
-        User user = new UserDAO().findById(username);
-        if (user == null) {
-            UIBeanHelper.setErrorMessage("User not registered: " + username);
-            return "failure";
-        }
-        String email = user.getEmail();
-        if (email == null || email.length() == 0) {
-            UIBeanHelper.setErrorMessage("No email address for username: "
-                    + username);
-            return "failure";
-        }
-
-        Properties p = new Properties();
-        String mailServer = System.getProperty("smtp.server", "smtp.broadinstitute.org");
-        p.put("mail.host", mailServer);
-        Session mailSession = Session.getDefaultInstance(p, null);
-        mailSession.setDebug(false);
-        MimeMessage msg = new MimeMessage(mailSession);
-        try {
-            // use numeric instead of alphabetic characters so we accidentally
-            // generate a 'naughty' word
-            String newPassword = RandomStringUtils.randomNumeric(8);
-            msg.setSubject("Your GenePattern Password");
-            msg
-                    .setText("Your GenePattern password has been reset to "
-                            + newPassword
-                            + ".\nPlease sign in to GenePattern to update your password.");
-            msg.setFrom(new InternetAddress("no-reply@genepattern.org"));
-            msg.setSentDate(new Date());
-            msg.addRecipient(Message.RecipientType.TO, new InternetAddress(
-                    email));
-            // try to encrypt the password before sending the email.
-            byte[] encryptedPassword = EncryptionUtil.encrypt(newPassword);
-            // try to send the email before changing the password.
-            Transport.send(msg);
-            user.setPassword(encryptedPassword);
-            UIBeanHelper.setInfoMessage("Your new password has been sent to "
-                    + email + ".");
-        } 
-        catch (NoSuchAlgorithmException e) {
-            log.error(e);
-            UIBeanHelper
-                    .setErrorMessage("Server configuration error: Unable to encrypt password. "
-                            + "\nContact the GenePattern server administrator for help.");
-            return "failure";
-        } 
-        catch (MessagingException e) {
-            log.error(e);
-            UIBeanHelper
-                    .setErrorMessage("Server configuration error: Unable to send email."
-                            + "\nContact the GenePattern server administrator for help.");
-            return "failure";
-        }
-        return "success";
-    }
+    private String username;
 
     public String getUsername() {
         return username;
@@ -91,4 +26,56 @@ public class ForgotPasswordBean {
     public void setUsername(String username) {
         this.username = username;
     }
+
+    public String resetPassword() {
+        final User user = new UserDAO(HibernateUtil.instance()).findById(username);
+        if (user == null) {
+            UIBeanHelper.setErrorMessage("User not registered: " + username);
+            return "failure";
+        }
+        final String email = user.getEmail();
+        if (email == null || email.length() == 0) {
+            UIBeanHelper.setErrorMessage("No email address for username: " + username);
+            return "failure";
+        }
+        
+        final String newPassword = RandomStringUtils.randomNumeric(8);
+        byte[] encryptedPassword;
+        try {
+            // try to encrypt the password before sending the email.
+            encryptedPassword = EncryptionUtil.encrypt(newPassword);
+        }
+        catch (NoSuchAlgorithmException e) {
+            log.error(e);
+            UIBeanHelper.setErrorMessage("Server configuration error: Unable to encrypt password. "
+                    + "\nContact the GenePattern server administrator for help.");
+            return "failure";
+        } 
+        
+        try {
+            sendResetPasswordMessage(email, newPassword);
+            user.setPassword(encryptedPassword);
+            UIBeanHelper.setInfoMessage("Your new password has been sent to " + email + ".");
+            return "success";
+        }
+        catch (Exception e) {
+            log.error(e);
+            UIBeanHelper.setErrorMessage("Unable to send email to '"+email+"': " + e.getLocalizedMessage() + ". " +
+                    "Contact the GenePattern server administrator for help.");
+            return "failure";
+        }
+    }
+
+    protected void sendResetPasswordMessage(final String to, final String newPassword) throws Exception {
+        final MailSender m = new MailSender.Builder()
+            .from("no-reply@genepattern.org")
+            .to(to)
+            .subject("Your GenePattern Password")
+            .message("Your GenePattern password has been reset to "
+                            + newPassword
+                            + ".\nPlease sign in to GenePattern to update your password.")
+        .build();
+        m.sendMessage();
+    }
+    
 }

--- a/test/src/org/genepattern/server/executor/CommandManagerFactoryTest.java
+++ b/test/src/org/genepattern/server/executor/CommandManagerFactoryTest.java
@@ -25,6 +25,7 @@ import org.genepattern.server.config.GpContext;
 import org.genepattern.server.config.GpServerProperties;
 import org.genepattern.server.config.Value;
 import org.genepattern.server.database.HibernateSessionManager;
+import org.genepattern.server.util.MailSender;
 import org.genepattern.server.webapp.jsf.ContactUsBean;
 import org.genepattern.webservice.JobInfo;
 import org.junit.Before;
@@ -193,8 +194,8 @@ public class CommandManagerFactoryTest {
                 ContactUsBean.DEFAULT_CONTACT_EMAIL, 
                 jobProperties.getProperty(ContactUsBean.PROP_CONTACT_EMAIL));
         assertEquals("'smtp.server", 
-                ContactUsBean.DEFAULT_SMTP_SERVER, 
-                jobProperties.getProperty(ContactUsBean.PROP_SMTP_SERVER));
+                MailSender.DEFAULT_SMTP_SERVER, 
+                jobProperties.getProperty(MailSender.PROP_SMTP_SERVER));
     }
 
     /**


### PR DESCRIPTION
Update the 'Email Reminder' and 'Forgot your password?' links to use the GpConfig file (instead of System.properties) for the smtp server configuration.

smtp.server=smtp.broadinstitute.org
smtp.from.email=no-reply@genepattern.org

