### PR TITLE
Fix for GP-6213, part 2, disregard System.properties

### DIFF
--- a/src/org/genepattern/server/webapp/jsf/CustomProperties.java
+++ b/src/org/genepattern/server/webapp/jsf/CustomProperties.java
@@ -1,6 +1,7 @@
 package org.genepattern.server.webapp.jsf;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -10,10 +11,12 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.apache.log4j.Logger;
+import org.genepattern.server.config.ServerConfigurationFactory;
 import org.genepattern.server.util.PropertiesManager_3_2;
 
-public class CustomProperties {
+public class CustomProperties implements Serializable {
     private static final Logger log = Logger.getLogger("CustomSettings.class");
+    private static final long serialVersionUID = 1330010307546274883L;
     
     public static final String GP_URL = "GenePatternURL";
 
@@ -41,7 +44,7 @@ public class CustomProperties {
         //first remove any existing keys with same name
         removeDuplicateCustomSetting(key);
         customSettings.add(new KeyValuePair(key, value));
-        PropertiesManager_3_2.storeChangesToCustomProperties(customSettings);
+        storeChangesToCustomProperties(true);
     }
 
     private void removeDuplicateCustomSetting(final String key) {
@@ -68,7 +71,7 @@ public class CustomProperties {
             if (element.getKey().equals(keyToRemove)) {
                 customSettings.remove(element);
                 System.getProperties().remove(keyToRemove);
-                PropertiesManager_3_2.storeChangesToCustomProperties(customSettings);
+                storeChangesToCustomProperties(true);
                 break;
             }
         }
@@ -78,13 +81,20 @@ public class CustomProperties {
         KeyValuePair gpURL = new KeyValuePair(GP_URL, genepatternURL);
         removeDuplicateCustomSetting(GP_URL);
         customSettings.add(gpURL);
-        PropertiesManager_3_2.storeChangesToCustomProperties(customSettings);
+        storeChangesToCustomProperties(true);
     }
 
-    public void storeChangesToCustomProperties() {
+    /**
+     * Save custom properties to file system and optionally reload the
+     * genepattern.properties and custom.properties files.
+     * 
+     * @param reloadConfiguration
+     */
+    public void storeChangesToCustomProperties(final boolean reloadConfiguration) {
         PropertiesManager_3_2.storeChangesToCustomProperties(customSettings);
-        //reload of genepattern.properties and custom.properties files after making changes
-        //    ServerConfigurationFactory.reloadConfiguration();
+        if (reloadConfiguration) {
+            ServerConfigurationFactory.reloadConfiguration();
+        }
     }
 
     protected static List<KeyValuePair> initCustomSettings() {

--- a/src/org/genepattern/server/webapp/jsf/CustomProperties.java
+++ b/src/org/genepattern/server/webapp/jsf/CustomProperties.java
@@ -2,12 +2,10 @@ package org.genepattern.server.webapp.jsf;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
 import org.apache.log4j.Logger;
@@ -99,13 +97,9 @@ public class CustomProperties implements Serializable {
 
     protected static List<KeyValuePair> initCustomSettings() {
         try {
-            Properties tmp = PropertiesManager_3_2.getCustomProperties();
-            List<KeyValuePair> customSettings = new ArrayList<KeyValuePair>();
-            for (Map.Entry entry : tmp.entrySet()) {
-                customSettings.add(new KeyValuePair((String) entry.getKey(), (String) entry.getValue()));
-            }
-            return customSettings;
-        } 
+            final Properties customProps = PropertiesManager_3_2.getCustomProperties();
+            return KeyValuePair.createListFromProperties(customProps);
+        }
         catch (IOException ioe) {
             log.error(ioe);
             return null;

--- a/src/org/genepattern/server/webapp/jsf/KeyValuePair.java
+++ b/src/org/genepattern/server/webapp/jsf/KeyValuePair.java
@@ -5,10 +5,28 @@
 package org.genepattern.server.webapp.jsf;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
 
 import org.genepattern.server.dm.UrlUtil;
 
 public class KeyValuePair implements Serializable {
+    private static final long serialVersionUID = 7245950250797266267L;
+
+    /**
+     * Create a new List of KeyValuePair items from a Properties instance.
+     * @param props
+     * @return
+     */
+    public static final List<KeyValuePair> createListFromProperties(final Properties props) {
+        final List<KeyValuePair> customSettings = new ArrayList<KeyValuePair>();
+        for(final String key : props.stringPropertyNames()) {
+            customSettings.add(new KeyValuePair(key, props.getProperty(key)));
+        }
+        return customSettings;        
+    }
+
     private String altKey;
     private String key;
     private String value;

--- a/src/org/genepattern/server/webapp/jsf/ServerSettingsBean.java
+++ b/src/org/genepattern/server/webapp/jsf/ServerSettingsBean.java
@@ -727,9 +727,9 @@ public class ServerSettingsBean implements Serializable {
     public void saveSettings(ActionEvent event) {
         UIBeanHelper.setInfoMessage("Property successfully updated");
         PropertiesManager_3_2.storeChanges(settings);
-        customProperties.storeChangesToCustomProperties();
         //force reload of genepattern.properties and custom.properties files
-        ServerConfigurationFactory.reloadConfiguration();
+        final boolean reloadConfiguration=true;
+        customProperties.storeChangesToCustomProperties(reloadConfiguration);
     }
 
     /**


### PR DESCRIPTION
Completed fix for GP-6213
* disregard System.properties when resolving substitution variables
* additional code cleanup
