### PR TITLE
GP-6475, Make 'commandPrefix.properties' a configuration property

### DIFF
--- a/src/org/genepattern/pipelines/ModuleJSON.java
+++ b/src/org/genepattern/pipelines/ModuleJSON.java
@@ -41,7 +41,7 @@ public class ModuleJSON extends JSONObject {
     
     public ModuleJSON(TaskInfo info, String username) {
         try {
-            final List<String> categories=new CategoryUtil().getCategoriesFromManifest(info);
+            final List<String> categories=CategoryUtil.getCategoriesFromManifest(info);
             
             this.setLsid(info.getLsid());
             this.setName(info.getName());

--- a/src/org/genepattern/server/config/CommandPrefixConfig.java
+++ b/src/org/genepattern/server/config/CommandPrefixConfig.java
@@ -1,0 +1,180 @@
+package org.genepattern.server.config;
+
+import java.net.MalformedURLException;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.genepattern.util.LSID;
+import org.genepattern.webservice.WebServiceException;
+
+/**
+ * Helper class for setting the command line prefix for a job based on the settings in the
+ *     'commandPrefix.properties' and 'taskPrefixMapping.properties' files.
+ * 
+ * @author pcarr
+ */
+public class CommandPrefixConfig {
+
+    public static String getCommandPrefix(final GpConfig gpConfig, final GpContext jobContext) 
+    throws MalformedURLException
+    {
+        final boolean isCommandLineJob = TaskType.JOB == jobContext.getTaskType();
+        final String lsidStr = jobContext.getLsid();
+        return getCommandPrefix(gpConfig, isCommandLineJob, lsidStr);
+    }
+
+    /**
+     * handle 'getCommandPrefix' for job in GenePatternAnalysisTask
+     * 
+     * Get the appropriate command prefix to use for this module. The hierarchy goes like this; 
+     * 1. task version specific entry in task prefix mapping 
+     * 2. task versionless entry in task prefix mapping 
+     * 3. default command prefix only applies to non-visualizers
+     * 
+     * @param taskInfoAttributes
+     * @return null if no command prefix is specified.
+     * @throws MalformedURLException
+     */
+    protected static String getCommandPrefix(final GpConfig gpConfig, final boolean isCommandLineJob, final String lsidStr) 
+            throws MalformedURLException
+    {
+        final LSID lsid=new LSID(lsidStr);
+        final Map<String,String> taskPrefixMapping = gpConfig.getTaskPrefixMappingProps().getProps();
+        final String commandPrefixName = getCommandPrefixName(taskPrefixMapping, lsid);
+
+        final Map<String,String> commandPrefixProps=gpConfig.getCommandPrefixProps().getProps();
+        final String commandPrefixCustom=commandPrefixProps.getOrDefault(commandPrefixName, null);
+        if (commandPrefixCustom == null && isCommandLineJob) {
+            // default command prefix only applies to command line jobs
+            return gpConfig.getCommandPrefixProps().getProps().getOrDefault("default", null);
+        }
+        return commandPrefixCustom;
+    }
+
+    /**
+     * For the given LSID instance, get the optional commandPrefixName from 
+     * the taskPrefixMapping.properties file.
+     * 
+     * The full lsid takes precedence over the versionless lsid.
+     *     {lsid}={prefixName}
+     *     {lsidNoVersion}={prefixName}
+     *     
+     * @return a commandPrefixName from the file or null if there are not matching lsids
+     */
+    protected static String getCommandPrefixName(final Map<String,String> taskPrefixMapping, final LSID lsid) 
+    {
+        final String commandPrefixName = taskPrefixMapping.getOrDefault( lsid.toString(), null );
+        if (commandPrefixName == null) {
+            return taskPrefixMapping.getOrDefault( lsid.toStringNoVersion(), null );
+        }
+        else {
+            return commandPrefixName;
+        }
+    }
+    
+    final GpConfig gpConfig;
+
+    public CommandPrefixConfig() {
+        this(ServerConfigurationFactory.instance());
+    }
+    public CommandPrefixConfig(final GpConfig gpConfig) {
+        this.gpConfig=gpConfig != null ? gpConfig : ServerConfigurationFactory.instance();
+    }
+
+    private GpConfig gpConfig() {
+        return gpConfig;
+    }
+
+    public String getDefaultCommandPrefix() {
+        return gpConfig().getCommandPrefixProps().getProps().getOrDefault("default", "");
+    }
+
+    /**
+     * handle 'getCommandPrefix' for job in GenePatternAnalysisTask
+     * 
+     * Get the appropriate command prefix to use for this module. The hierarchy goes like this; 
+     * 1. task version specific entry in task prefix mapping 
+     * 2. task versionless entry in task prefix mapping 
+     * 3. default command prefix only applies to non-visualizers
+     * 
+     * @param taskInfoAttributes
+     * @return null if no command prefix is specified.
+     * @throws MalformedURLException
+     */
+    public String getCommandPrefix(final GpContext jobContext) 
+    throws MalformedURLException
+    {
+        if (jobContext==null) {
+            throw new IllegalArgumentException("jobContext is null");
+        } 
+        final boolean isCommandLineJob = TaskType.JOB == jobContext.getTaskType();
+        final String lsidStr = jobContext.getLsid();
+        final LSID lsid=new LSID(lsidStr);
+        final Map<String,String> taskPrefixMapping = gpConfig.getTaskPrefixMappingProps().getProps();
+        final String commandPrefixName = getCommandPrefixName(taskPrefixMapping, lsid);
+
+        final Map<String,String> commandPrefixProps=gpConfig.getCommandPrefixProps().getProps();
+        final String commandPrefixCustom=commandPrefixProps.getOrDefault(commandPrefixName, null);
+        if (commandPrefixCustom == null && isCommandLineJob) {
+            // default command prefix only applies to command line jobs
+            return gpConfig.getCommandPrefixProps().getProps().getOrDefault("default", null);
+        }
+        return commandPrefixCustom;
+    }
+
+    public Properties getCommandPrefixProperties() {
+        return gpConfig().getCommandPrefixProps().cloneProperties();
+    }
+
+    public Properties getTaskPrefixMappingProperties() {
+        return gpConfig().getTaskPrefixMappingProps().cloneProperties();
+    }
+
+    /** handle 'save default' link */
+    public void saveDefaultCommandPrefix(final String defaultCommandPrefix) {
+        addCommandPrefix("default", defaultCommandPrefix);
+    }
+
+    /** handle 'add prefix' link */
+    public void addCommandPrefix(final String name, final String value) {
+        gpConfig().getCommandPrefixProps().saveProperty(name, value);
+    }
+
+    /** handle 'delete' prefix link */
+    public void deleteCommandPrefix(final String commandPrefixName) {
+        gpConfig().getCommandPrefixProps().deleteProperty(commandPrefixName);
+
+        final Properties tpm = new Properties();
+        tpm.putAll(gpConfig().getTaskPrefixMappingProps().getProps());
+        boolean tpmChanged = false;
+        for (final Object oKey : tpm.keySet()) {
+            final String key = (String) oKey;
+            final String prefixInUse = tpm.getProperty(key);
+            if (prefixInUse.equals(commandPrefixName)) {
+                tpm.remove(key);
+                tpmChanged = true;
+            }
+        }
+        if (tpmChanged) {
+            gpConfig().getTaskPrefixMappingProps().saveProperties(tpm);
+        }
+    }
+
+    /** handle 'add mapping' link */
+    public void addTaskPrefixMapping(final List<String> baseLsids, final String commandPrefixName) throws MalformedURLException, WebServiceException {
+        final Record taskPrefixMappingProps = gpConfig().getTaskPrefixMappingProps();
+
+        final Properties p = taskPrefixMappingProps.cloneProperties();
+        for (final String baseLsid : baseLsids) {
+            p.setProperty(baseLsid, commandPrefixName);
+        }
+        taskPrefixMappingProps.saveProperties(p);
+    } 
+
+    /** handle 'delete' mapping link */
+    public void deleteTaskPrefixMapping(final String baseLsid) {
+        gpConfig().getTaskPrefixMappingProps().deleteProperty(baseLsid);
+    }
+
+}

--- a/src/org/genepattern/server/config/GpConfig.java
+++ b/src/org/genepattern/server/config/GpConfig.java
@@ -6,6 +6,7 @@ package org.genepattern.server.config;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
@@ -703,7 +704,30 @@ public class GpConfig {
     public Map<String,String> getBuildProperties() {
         return  buildProperties;
     }
-    
+
+    /**
+     * Get the 'default' command prefix declared in the resources/commandPrefix.properties file.
+     */
+    public String getDefaultCommandPrefix() {
+        return serverProperties
+                .getCommandPrefixProps()
+                .getProps().getOrDefault("default", "");
+    }
+
+    /**
+     * Get the properties loaded from the resources/commandPrefix.properties file.
+     */
+    protected Record getCommandPrefixProps() {
+        return serverProperties.getCommandPrefixProps();
+    }
+
+    /**
+     * Get the properties loaded from the resources/taskPrefixMapping.properties file.
+     */
+    protected Record getTaskPrefixMappingProps() {
+        return serverProperties.getTaskPrefixMappingProps();
+    }
+
     /**
      * Get the database configuration properties loaded from the <resources>/database_default.properties and
      * optionally from the <resources>/database_custom.properties files.
@@ -981,6 +1005,24 @@ public class GpConfig {
             return queueId;
         }
         return defaultValue;
+    }
+    
+    /**
+     * Get the optional command line prefix for a job.
+     * 
+     * @param jobContext
+     * @return
+     * @throws IllegalArgumentException
+     */
+    public String getCommandPrefix(final GpContext jobContext) 
+    throws IllegalArgumentException, MalformedURLException
+    {
+        if (jobContext==null) {
+            throw new IllegalArgumentException("jobContext is null");
+        }
+        final boolean isCommandLineJob = TaskType.JOB == jobContext.getTaskType();
+        final String lsidStr = jobContext.getLsid();
+        return CommandPrefixConfig.getCommandPrefix(this, isCommandLineJob, lsidStr);
     }
 
     //helper methods for locating server files and folders

--- a/src/org/genepattern/server/config/GpContext.java
+++ b/src/org/genepattern/server/config/GpContext.java
@@ -21,16 +21,7 @@ import org.genepattern.webservice.TaskInfoCache;
 
 public class GpContext {
     private static final Logger log = Logger.getLogger(GpContext.class);
-
-    private String userId = null;
-    private TaskInfo taskInfo = null;
-    private File taskLibDir = null;  // aka installation dir, the directory to which the task was installed
-    private JobInfo jobInfo = null;
-    private Integer jobNumber = null;
-    private JobInput jobInput = null;
-    private boolean isAdmin=false;
-    private JobPermissions jobPermissions=null;
-
+    
     public static GpContext createContextForUser(final String userId) {
         return createContextForUser(userId, false);
     }
@@ -192,27 +183,21 @@ public class GpContext {
         return context;
     }
 
+    private String userId = null;
+    private TaskInfo taskInfo = null;
+    private TaskType taskType = null;
+    private File taskLibDir = null;  // aka installation dir, the directory to which the task was installed
+    private JobInfo jobInfo = null;
+    private Integer jobNumber = null;
+    private JobInput jobInput = null;
+    private boolean isAdmin=false;
+    private JobPermissions jobPermissions=null;
+
     /**
      * @deprecated
      */
     public GpContext() {
     }
-
-//    void setCheckSystemProperties(boolean b) {
-//        this.checkSystemProperties = b;
-//    }
-//
-//    public boolean getCheckSystemProperties() {
-//        return checkSystemProperties;
-//    }
-
-//    void setCheckPropertiesFiles(boolean b) {
-//        this.checkPropertiesFiles = b;
-//    }
-//
-//    public boolean getCheckPropertiesFiles() {
-//        return checkPropertiesFiles;
-//    }
 
     void setUserId(String userId) {
         this.userId = userId;
@@ -223,6 +208,9 @@ public class GpContext {
 
     public void setTaskInfo(TaskInfo taskInfo) {
         this.taskInfo = taskInfo;
+        if (this.taskInfo != null) {
+            this.taskType=TaskType.initTaskType(this.taskInfo);
+        }
     }
     public TaskInfo getTaskInfo() {
         return this.taskInfo;
@@ -294,6 +282,10 @@ public class GpContext {
             return jobInfo.getTaskName();
         }
         return null;
+    }
+    
+    public TaskType getTaskType() {
+        return taskType;
     }
 
     void setJobPermissions(final JobPermissions jobPermissions) {

--- a/src/org/genepattern/server/config/Record.java
+++ b/src/org/genepattern/server/config/Record.java
@@ -1,0 +1,106 @@
+package org.genepattern.server.config;
+
+import java.io.File;
+import java.util.Properties;
+
+import org.apache.log4j.Logger;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+
+/**
+ * Helper class to keep a record of the Properties loaded from a File.
+ * 
+ * @author pcarr
+ */
+public class Record {
+    private static final Logger log = Logger.getLogger(Record.class);
+
+    /**
+     * Create a new record from the propFile. 
+     * Special-cases:
+     *     when propFile is null, return null
+     *     when propFile does not exist, return an empty record
+     * 
+     * @param propFile, the properties file to load
+     * @return
+     */
+    public static final Record createFromPropertiesFile(final File propFile) {
+        if (propFile==null) {
+            return null;
+        }
+        return new Record(propFile);
+    }
+    
+    private final File propFile;
+    private final long dateLoaded;
+    final ImmutableMap<String,String> props;
+
+    public Record(final Properties from) {
+        this.propFile=null;
+        this.dateLoaded=System.currentTimeMillis();
+        this.props=Maps.fromProperties(from);
+    }
+
+    public Record(final File propFile) {
+        if (propFile==null) {
+            throw new IllegalArgumentException("propFile==null");
+        }
+        this.propFile=propFile;
+        final Properties props=GpServerProperties.loadProps(propFile);
+        this.dateLoaded = System.currentTimeMillis();
+        this.props=Maps.fromProperties(props);
+    }
+    
+    /** get an immutable map of the properties */
+    public ImmutableMap<String,String> getProps() {
+        return props;
+    }
+    
+    /** get a copy of the properties as a Properties instance */
+    public Properties cloneProperties() {
+        Properties p = new Properties();
+        p.putAll(props);
+        return p;
+    }
+    
+    public File getPropertiesFile() {
+        return propFile;
+    }
+
+    public long getDateLoaded() {
+        return dateLoaded;
+    }
+
+    public Record reloadProps() {
+        return new Record(propFile);
+    }
+    
+    public void saveProperty(final String key, final String value) {
+        final Record existingRecord=reloadProps();
+        final Properties props=new Properties();
+        props.putAll(existingRecord.getProps());
+        props.setProperty(key, value);
+        saveProperties(props);
+    }
+    
+    public void deleteProperty(final String key) {
+        final Record existingRecord=reloadProps();
+        final Properties props=new Properties();
+        props.putAll(existingRecord.getProps());
+        if (props.containsKey(key)) { 
+            props.remove(key);
+            saveProperties(props);
+        }
+    }
+
+    public void saveProperties(final Properties properties) {
+        boolean success = GpServerProperties.writePropertiesIgnoreError(properties, this.propFile, " ");
+        if (success) {
+            ServerConfigurationFactory.reloadConfiguration();
+        }
+        else {
+            log.error("Error saving properties to file: "+this.propFile);
+        }
+    }
+}

--- a/src/org/genepattern/server/config/TaskType.java
+++ b/src/org/genepattern/server/config/TaskType.java
@@ -1,0 +1,41 @@
+package org.genepattern.server.config;
+
+import org.genepattern.util.GPConstants;
+import org.genepattern.webservice.TaskInfo;
+
+/**
+ * The taskType for a module. 
+ * Use this as the canonical representation for the GpContext class.
+ * 
+ * @author pcarr
+ */
+public enum TaskType {
+    JOB,
+    VISUALIZER,
+    JAVASCRIPT,
+    PIPELINE,
+    NOT_SET;
+
+    public static TaskType initTaskType(final TaskInfo taskInfo) {
+        if (taskInfo == null || taskInfo.getTaskInfoAttributes() == null) {
+            return TaskType.NOT_SET;
+        };
+        final String taskType=taskInfo.getTaskInfoAttributes().get(GPConstants.TASK_TYPE);
+        
+        if (GPConstants.TASK_TYPE_VISUALIZER.equalsIgnoreCase(taskType)) {
+            return VISUALIZER;
+        }
+        else if (GPConstants.TASK_TYPE_JAVASCRIPT.equalsIgnoreCase(taskType)) {
+            return JAVASCRIPT;
+        }
+        // note: 'endsWith' idiom is from a very early implementation in the TaskInfo class
+        //     it's not clear to me if we need to match the pattern '*pipeline' or if an
+        //     exact match is better
+        else if (taskType.endsWith("pipeline")) {
+            return PIPELINE;
+        }
+        else {
+            return JOB;
+        }
+    }
+}

--- a/src/org/genepattern/server/webapp/jsf/CommandPrefixBean.java
+++ b/src/org/genepattern/server/webapp/jsf/CommandPrefixBean.java
@@ -34,7 +34,7 @@ public class CommandPrefixBean {
     private String defaultCommandPrefix;
     private String newPrefixName;
     private String newPrefixValue;
-    private List newMappingLSID;
+    private List<String> newMappingLSID;
     private String newMappingPrefix;
 
     PropertiesManager_3_2 pm = null;
@@ -170,11 +170,11 @@ public class CommandPrefixBean {
         this.newPrefixValue = newPrefix;
     }
 
-    public List getNewMappingLSID() {
+    public List<String> getNewMappingLSID() {
         return newMappingLSID;
     }
 
-    public void setNewMappingLSID(List newMappingLSID) {
+    public void setNewMappingLSID(List<String> newMappingLSID) {
         this.newMappingLSID = newMappingLSID;
     }
 
@@ -231,11 +231,9 @@ public class CommandPrefixBean {
      *            ignored
      */
     public void savePrefixTaskMapping(ActionEvent event) throws MalformedURLException, WebServiceException {
-        Properties p = pm.getTaskPrefixMapping();
-
-        for (String anLsid : (List<String>) newMappingLSID) {
-            String lsid = lsidFromName(anLsid);
-
+        final Properties p = pm.getTaskPrefixMapping();
+        for (final String anLsid : newMappingLSID) {
+            final String lsid = lsidFromName(anLsid);
             p.setProperty(lsid, newMappingPrefix);
         }
         pm.saveProperties(TASK_PREFIX_MAPPING, p);

--- a/src/org/genepattern/server/webapp/jsf/CustomProperties.java
+++ b/src/org/genepattern/server/webapp/jsf/CustomProperties.java
@@ -98,7 +98,7 @@ public class CustomProperties implements Serializable {
     protected static List<KeyValuePair> initCustomSettings() {
         try {
             final Properties customProps = PropertiesManager_3_2.getCustomProperties();
-            return KeyValuePair.createListFromProperties(customProps);
+            return KeyValuePair.fromProperties(customProps);
         }
         catch (IOException ioe) {
             log.error(ioe);

--- a/src/org/genepattern/server/webapp/jsf/KeyValuePair.java
+++ b/src/org/genepattern/server/webapp/jsf/KeyValuePair.java
@@ -6,27 +6,83 @@ package org.genepattern.server.webapp.jsf;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.genepattern.server.dm.UrlUtil;
 
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+
 public class KeyValuePair implements Serializable {
     private static final long serialVersionUID = 7245950250797266267L;
+    
+    /** sort by key, ignore case, treat null key as empty string */
+    public static final Comparator<KeyValuePair> sortByKeyIgnoreCase = new Comparator<KeyValuePair>() {
+        @Override
+        public int compare(final KeyValuePair o1, final KeyValuePair o2) {
+            final String k1 = o1 == null ? "" : Strings.nullToEmpty(o1.getKey());
+            final String k2 = o2 == null ? "" : Strings.nullToEmpty(o2.getKey());
+            return k1.compareToIgnoreCase(k2);
+        } 
+    };
+
+    /** sort by key then by value, ignore case, treat null as empty */
+    public static final Comparator<KeyValuePair> sortByKeyValueIgnoreCase = new Comparator<KeyValuePair>() {
+        public int compare(KeyValuePair arg0, KeyValuePair arg1) {
+            final String k0 = arg0 == null ? "" : Strings.nullToEmpty( arg0.getKey() );
+            final String k1 = arg1 == null ? "" : Strings.nullToEmpty( arg1.getKey() );
+            //sort by key then by value
+            int c = k0.compareToIgnoreCase(k1);
+            if (c == 0) {
+                final String v0 = arg0 == null ? "" : arg0.getValue();
+                final String v1 = arg1 == null ? "" : arg1.getValue();
+                c = v0.compareToIgnoreCase(v1);
+            }
+            return c;
+        }
+    };
+
+    protected static SortedSet<KeyValuePair> setFromProperties(final Properties props) {
+        return setFromProperties(props, sortByKeyIgnoreCase);
+    }
+    
+    /**
+     * Create a new SortedSet of KeyValuePair entries from a Properties instance.
+     */
+    protected static SortedSet<KeyValuePair> setFromProperties(final Properties props, final Comparator<KeyValuePair> c) {
+        final SortedSet<KeyValuePair> s = new TreeSet<KeyValuePair>(c);
+        for(final String key : props.stringPropertyNames()) {
+            s.add(new KeyValuePair(key, props.getProperty(key)));
+        }
+        return s;
+    }
 
     /**
      * Create a new List of KeyValuePair items from a Properties instance.
      * @param props
      * @return
      */
-    public static final List<KeyValuePair> createListFromProperties(final Properties props) {
-        final List<KeyValuePair> customSettings = new ArrayList<KeyValuePair>();
-        for(final String key : props.stringPropertyNames()) {
-            customSettings.add(new KeyValuePair(key, props.getProperty(key)));
-        }
-        return customSettings;        
+    public static final List<KeyValuePair> fromProperties(final Properties props) {
+        Set<KeyValuePair> set=setFromProperties(props, sortByKeyIgnoreCase);
+        final List<KeyValuePair> list = new ArrayList<KeyValuePair>();
+        list.addAll(set);
+        return list;
     }
 
+    public static ImmutableList<KeyValuePair> listFromProperties(final Properties props) { 
+        return listFromProperties(props, sortByKeyIgnoreCase);
+    }
+
+    public static ImmutableList<KeyValuePair> listFromProperties(final Properties props, final Comparator<KeyValuePair> c) { 
+        Set<KeyValuePair> set=setFromProperties(props, c);
+        return ImmutableList.copyOf( set );
+    }
+    
     private String altKey;
     private String key;
     private String value;

--- a/src/org/genepattern/util/LSID.java
+++ b/src/org/genepattern/util/LSID.java
@@ -15,48 +15,37 @@ import java.text.ParseException;
 import java.util.StringTokenizer;
 
 public class LSID implements Comparable<LSID>, Serializable {
-
     /** computed servialVersionUID */
     private static final long serialVersionUID = -1579338628906221673L;
-
-    String authority = "";
-
-    String namespace = "";
-
-    String identifier = "";
-
-    String version = "";
-
-    protected boolean precomputed = false;
-
+    
     public static final String URN = "urn";
-
     public static final String SCHEME = "lsid";
-
     public static final String DELIMITER = ":";
-
     public static final String VERSION_DELIMITER = ".";
 
     // URN encoding constants
-
     protected static final String encodable = "\\\"&<>[]^`{|}~%/?#";
-
     protected static final String escape = "%";
-
     protected static final String UTF8 = "utf-8";
+
+    protected String authority = "";
+    protected String namespace = "";
+    protected String identifier = "";
+    protected String version = "";
+    protected boolean precomputed = false;
 
     // sample valid LSID:
     // urn:lsid:broadinstitute.org:genepatternmodule:123:2
 
-    public LSID(String lsid) throws MalformedURLException {
+    public LSID(final String lsid) throws MalformedURLException {
         if (lsid == null || lsid.length() == 0) {
             // empty initializer is okay, it will be set later
             return;
         }
-        String usage = lsid + " must be of the form " + URN + DELIMITER
+        final String usage = lsid + " must be of the form " + URN + DELIMITER
                 + SCHEME + DELIMITER + "authority" + DELIMITER + "namespace"
                 + DELIMITER + "identifier" + DELIMITER + "version";
-        StringTokenizer stLSID = new StringTokenizer(lsid, DELIMITER);
+        final StringTokenizer stLSID = new StringTokenizer(lsid, DELIMITER);
         int numParts = stLSID.countTokens();
         if (numParts != 5 && numParts != 6) {
             throw new MalformedURLException("Wrong number of parts: " + usage);
@@ -179,10 +168,8 @@ public class LSID implements Comparable<LSID>, Serializable {
                 }
             }
             if (stOtherVersion.hasMoreTokens()) {
-                // other version has more parts than this, but was equal until
-                // now
-                // That means that it has an extra minor level and is therefore
-                // later
+                // other version has more parts than this, but was equal until now
+                // That means that it has an extra minor level and is therefore later
                 return 1;
             }
             // completely equal!

--- a/src/org/genepattern/util/LSID.java
+++ b/src/org/genepattern/util/LSID.java
@@ -27,6 +27,9 @@ public class LSID implements Comparable<LSID>, Serializable {
     protected static final String encodable = "\\\"&<>[]^`{|}~%/?#";
     protected static final String escape = "%";
     protected static final String UTF8 = "utf-8";
+    
+    protected static final String usage = 
+        "lsid must be of the form urn:lsid:{authority}:{namespace}:{identifier}[:{version}]";
 
     protected String authority = "";
     protected String namespace = "";
@@ -42,19 +45,16 @@ public class LSID implements Comparable<LSID>, Serializable {
             // empty initializer is okay, it will be set later
             return;
         }
-        final String usage = lsid + " must be of the form " + URN + DELIMITER
-                + SCHEME + DELIMITER + "authority" + DELIMITER + "namespace"
-                + DELIMITER + "identifier" + DELIMITER + "version";
         final StringTokenizer stLSID = new StringTokenizer(lsid, DELIMITER);
         int numParts = stLSID.countTokens();
         if (numParts != 5 && numParts != 6) {
-            throw new MalformedURLException("Wrong number of parts: " + usage);
+            throw new MalformedURLException("lsid='"+lsid+"', Wrong number of parts: " + usage);
         }
         if (!stLSID.nextToken().equals(URN)) {
-            throw new MalformedURLException("Bad or missing URN: " + usage);
+            throw new MalformedURLException("lsid='"+lsid+"', Bad or missing URN: " + usage);
         }
         if (!stLSID.nextToken().equals(SCHEME)) {
-            throw new MalformedURLException("Bad or missing SCHEME: " + usage);
+            throw new MalformedURLException("lsid='"+lsid+"', Bad or missing SCHEME: " + usage);
         }
         setAuthority(decode(stLSID.nextToken()));
         setNamespace(decode(stLSID.nextToken()));

--- a/test/src/org/genepattern/server/config/TestGpServerPropertiesRecord.java
+++ b/test/src/org/genepattern/server/config/TestGpServerPropertiesRecord.java
@@ -37,27 +37,27 @@ public class TestGpServerPropertiesRecord {
     @Test()
     public void testFromFile() {
         final File testProps=FileUtil.getSourceFile(this.getClass(), "test.properties");
-        GpServerProperties.Record record=new GpServerProperties.Record(testProps);
-        assertEquals("properties.size", 1, record.getProperties().size());
-        assertEquals("GenePatternURL", "http://testserver.test.com/gp/", record.getProperties().get("GenePatternURL"));
+        Record record=new Record(testProps);
+        assertEquals("properties.size", 1, record.getProps().size());
+        assertEquals("GenePatternURL", "http://testserver.test.com/gp/", record.getProps().get("GenePatternURL"));
     }
 
     @Test()
     public void testFromProperties() {
         final Properties props=new Properties();
         props.put("GenePatternURL", "http://127.0.0.1:8080/gp/");
-        GpServerProperties.Record record=new GpServerProperties.Record(props);
+        Record record=new Record(props);
         // verify that the record is based on a snapshot copy of the properties from the constructor
         props.clear();
-        assertEquals("properties.size", 1, record.getProperties().size());
-        assertEquals("GenePatternURL", "http://127.0.0.1:8080/gp/", record.getProperties().get("GenePatternURL"));
+        assertEquals("properties.size", 1, record.getProps().size());
+        assertEquals("GenePatternURL", "http://127.0.0.1:8080/gp/", record.getProps().get("GenePatternURL"));
     }
 
     @Test(expected = IllegalArgumentException.class )
     public void testNullFile() {
         final File nullFile=null;
         //GpServerProperties.Record record=
-                new GpServerProperties.Record(nullFile);
+                new Record(nullFile);
     }
     
     @Test
@@ -67,15 +67,15 @@ public class TestGpServerPropertiesRecord {
         File testProps=tmp.newFile("test.properties");
         writePropsToFile(props, testProps);
         
-        GpServerProperties.Record record=new GpServerProperties.Record(testProps);
-        assertEquals("properties.size", 1, record.getProperties().size());
-        assertEquals("GenePatternURL", "http://127.0.0.1:8080/gp/", record.getProperties().get("GenePatternURL"));
+        Record record=new Record(testProps);
+        assertEquals("properties.size", 1, record.getProps().size());
+        assertEquals("GenePatternURL", "http://127.0.0.1:8080/gp/", record.getProps().get("GenePatternURL"));
         boolean success=testProps.delete();
         assertEquals("deleted tmp testPropsFile="+testProps, true, success);
         final long initDateLoaded=record.getDateLoaded();
         Thread.sleep(100);
         record = record.reloadProps();
-        assertEquals("properties.size", 0, record.getProperties().size());
+        assertEquals("properties.size", 0, record.getProps().size());
         assertTrue("check dateLoaded", record.getDateLoaded()>initDateLoaded);
     }
     
@@ -83,15 +83,15 @@ public class TestGpServerPropertiesRecord {
     @Test 
     public void immutableProperties() {
         final File testProps=FileUtil.getSourceFile(this.getClass(), "test.properties");
-        GpServerProperties.Record record=new GpServerProperties.Record(testProps);
+        Record record=new Record(testProps);
         try {
-            record.getProperties().put("GenePatternURL", "bogusValue");
+            record.getProps().put("GenePatternURL", "bogusValue");
         }
         catch (Throwable t) {
             // ignore (expected = UnsupportedOperationException.class)
         }
-        assertEquals("properties.size", 1, record.getProperties().size());
-        assertEquals("GenePatternURL", "http://testserver.test.com/gp/", record.getProperties().get("GenePatternURL"));
+        assertEquals("properties.size", 1, record.getProps().size());
+        assertEquals("GenePatternURL", "http://testserver.test.com/gp/", record.getProps().get("GenePatternURL"));
     }
     
 }

--- a/test/src/org/genepattern/server/config/TestGpServerPropertiesRecord.java
+++ b/test/src/org/genepattern/server/config/TestGpServerPropertiesRecord.java
@@ -3,6 +3,9 @@
  *******************************************************************************/
 package org.genepattern.server.config;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -10,7 +13,6 @@ import java.util.Properties;
 
 
 import org.genepattern.junitutil.FileUtil;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -34,10 +36,10 @@ public class TestGpServerPropertiesRecord {
 
     @Test()
     public void testFromFile() {
-            final File testProps=FileUtil.getSourceFile(this.getClass(), "test.properties");
+        final File testProps=FileUtil.getSourceFile(this.getClass(), "test.properties");
         GpServerProperties.Record record=new GpServerProperties.Record(testProps);
-        Assert.assertEquals("properties.size", 1, record.getProperties().size());
-        Assert.assertEquals("GenePatternURL", "http://testserver.test.com/gp/", record.getProperties().get("GenePatternURL"));
+        assertEquals("properties.size", 1, record.getProperties().size());
+        assertEquals("GenePatternURL", "http://testserver.test.com/gp/", record.getProperties().get("GenePatternURL"));
     }
 
     @Test()
@@ -47,8 +49,8 @@ public class TestGpServerPropertiesRecord {
         GpServerProperties.Record record=new GpServerProperties.Record(props);
         // verify that the record is based on a snapshot copy of the properties from the constructor
         props.clear();
-        Assert.assertEquals("properties.size", 1, record.getProperties().size());
-        Assert.assertEquals("GenePatternURL", "http://127.0.0.1:8080/gp/", record.getProperties().get("GenePatternURL"));
+        assertEquals("properties.size", 1, record.getProperties().size());
+        assertEquals("GenePatternURL", "http://127.0.0.1:8080/gp/", record.getProperties().get("GenePatternURL"));
     }
 
     @Test(expected = IllegalArgumentException.class )
@@ -66,15 +68,30 @@ public class TestGpServerPropertiesRecord {
         writePropsToFile(props, testProps);
         
         GpServerProperties.Record record=new GpServerProperties.Record(testProps);
-        Assert.assertEquals("properties.size", 1, record.getProperties().size());
-        Assert.assertEquals("GenePatternURL", "http://127.0.0.1:8080/gp/", record.getProperties().get("GenePatternURL"));
+        assertEquals("properties.size", 1, record.getProperties().size());
+        assertEquals("GenePatternURL", "http://127.0.0.1:8080/gp/", record.getProperties().get("GenePatternURL"));
         boolean success=testProps.delete();
-        Assert.assertEquals("deleted tmp testPropsFile="+testProps, true, success);
+        assertEquals("deleted tmp testPropsFile="+testProps, true, success);
         final long initDateLoaded=record.getDateLoaded();
         Thread.sleep(100);
-        record.reloadProps();
-        Assert.assertEquals("properties.size", 0, record.getProperties().size());
-        Assert.assertTrue("check dateLoaded", record.getDateLoaded()>initDateLoaded);
+        record = record.reloadProps();
+        assertEquals("properties.size", 0, record.getProperties().size());
+        assertTrue("check dateLoaded", record.getDateLoaded()>initDateLoaded);
+    }
+    
+    @SuppressWarnings("deprecation")
+    @Test 
+    public void immutableProperties() {
+        final File testProps=FileUtil.getSourceFile(this.getClass(), "test.properties");
+        GpServerProperties.Record record=new GpServerProperties.Record(testProps);
+        try {
+            record.getProperties().put("GenePatternURL", "bogusValue");
+        }
+        catch (Throwable t) {
+            // ignore (expected = UnsupportedOperationException.class)
+        }
+        assertEquals("properties.size", 1, record.getProperties().size());
+        assertEquals("GenePatternURL", "http://testserver.test.com/gp/", record.getProperties().get("GenePatternURL"));
     }
     
 }

--- a/website/pages/serverSettingsCLP.xhtml
+++ b/website/pages/serverSettingsCLP.xhtml
@@ -52,7 +52,7 @@
                     <h:inputText size="50" value="#{commandPrefixBean.newPrefixValue}" id="newPrefixVal" />
                 </td>
                 <td width="10%">
-                    <h:commandLink value="add prefix" actionListener="#{commandPrefixBean.saveCommandPrefixes}" />
+                    <h:commandLink value="add prefix" actionListener="#{commandPrefixBean.addPrefix}" />
                 </td>
             </tr>
             <tr class="settingperameter">
@@ -138,7 +138,7 @@
                     </h:selectOneMenu>
                 </td>
                 <td width="10%">
-                    <h:commandLink value="add mapping" actionListener="#{commandPrefixBean.savePrefixTaskMapping}" />
+                    <h:commandLink value="add mapping" actionListener="#{commandPrefixBean.addTaskPrefixMapping}" />
                 </td>
             </tr>
         </table>


### PR DESCRIPTION
Initial fix for GP-6475 ready for testing on develop branch

* incorporate 'commandPrefix.properties' and 'taskPrefixMapping.properties' files into the GpConfig instance
* replace relevant System.getProperty and System.setProperty with GpConfig commands