### PR TITLE
updated REST '/tasks' json format of job.inputParams, GP-7403 part 2

### DIFF
--- a/src/org/genepattern/modules/ParametersJSON.java
+++ b/src/org/genepattern/modules/ParametersJSON.java
@@ -9,15 +9,16 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletRequest;
-
 import org.apache.log4j.Logger;
-import org.genepattern.server.job.input.*;
+import org.genepattern.server.job.input.GroupInfo;
+import org.genepattern.server.job.input.NumValues;
+import org.genepattern.server.job.input.ParamListHelper;
+import org.genepattern.server.job.input.RangeValues;
+import org.genepattern.server.job.input.RangeValuesParser;
 import org.genepattern.server.job.input.choice.ChoiceInfo;
 import org.genepattern.server.job.input.choice.ChoiceInfoHelper;
 import org.genepattern.util.GPConstants;
 import org.genepattern.webservice.ParameterInfo;
-import org.genepattern.webservice.TaskInfo;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -229,11 +230,11 @@ public class ParametersJSON extends JSONObject {
         }
     }
 
-    public void initChoice(final HttpServletRequest request, final TaskInfo taskInfo, final ParameterInfo pInfo, final boolean initDropdown) {
+    public void addChoiceInfo(final String parentHref, final ParameterInfo pInfo, final boolean initDropdown) {
         try {
             final ChoiceInfo choiceInfo = ChoiceInfoHelper.initChoiceInfo(pInfo, initDropdown);
             if (choiceInfo != null) {
-                JSONObject choiceInfoJson=ChoiceInfoHelper.initChoiceInfoJson(request, taskInfo, choiceInfo);
+                JSONObject choiceInfoJson=ChoiceInfoHelper.initChoiceInfoJson(parentHref, choiceInfo);
                 this.put("choiceInfo", choiceInfoJson);
             }
         }

--- a/src/org/genepattern/server/job/input/choice/ChoiceInfoHelper.java
+++ b/src/org/genepattern/server/job/input/choice/ChoiceInfoHelper.java
@@ -8,15 +8,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import javax.servlet.http.HttpServletRequest;
-
 import org.apache.log4j.Logger;
-import org.genepattern.server.webapp.rest.api.v1.task.TasksResource;
 import org.genepattern.webservice.ParameterInfo;
-import org.genepattern.webservice.TaskInfo;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import com.google.common.base.Strings;
 
 /**
  * 
@@ -155,22 +153,31 @@ public class ChoiceInfoHelper {
         }
     }
 
+    public static final String initChoiceInfoHref(final String parentHref, final ChoiceInfo choiceInfo) {
+        if (choiceInfo==null) {
+            return null;
+        }
+        if (Strings.isNullOrEmpty(parentHref)) {
+            return null;
+        }
+        if (Strings.isNullOrEmpty(choiceInfo.getParamName())) {
+            return null;
+        }
+        final String choiceInfoHref = parentHref + "/" + choiceInfo.getParamName()  + "/choiceInfo.json";
+        return choiceInfoHref;
+    }
+    
     /**
      * Get the JSON representation for the given choiceInfo.
-     * 
-     * @see TasksResource#getChoiceInfo(javax.ws.rs.core.UriInfo, String, String, HttpServletRequest)
-     * 
-     * @param pinfo
-     * @return
      */
-    final static public JSONObject initChoiceInfoJson(final HttpServletRequest request, final TaskInfo taskInfo, final ChoiceInfo choiceInfo) throws JSONException {
+    final static public JSONObject initChoiceInfoJson(final String parentHref, final ChoiceInfo choiceInfo) throws JSONException {
         if (choiceInfo==null) {
             throw new IllegalArgumentException("choiceInfo==null");
         }
         final JSONObject json=new JSONObject();
-        if (request != null && taskInfo != null && isSet(choiceInfo.getParamName())) {
-            final String href=TasksResource.getChoiceInfoPath(request, taskInfo, choiceInfo.getParamName());
-            json.put("href", href);
+        final String choiceInfoHref=initChoiceInfoHref(parentHref, choiceInfo);
+        if (!Strings.isNullOrEmpty(choiceInfoHref)) {
+            json.put("href", choiceInfoHref);
         }
         if (isSet(choiceInfo.getChoiceDir())) {
             json.put(ChoiceInfo.PROP_CHOICE_DIR, choiceInfo.getChoiceDir());

--- a/src/org/genepattern/server/webapp/rest/RunTaskServlet.java
+++ b/src/org/genepattern/server/webapp/rest/RunTaskServlet.java
@@ -374,8 +374,9 @@ public class RunTaskServlet extends HttpServlet
             if (jobConfigParams != null) {
                 final JSONObject jobConfigGroupJson=jobConfigParams.getInputParamGroup().toJson();
                 paramGroupsJson.put(jobConfigGroupJson);
+                final String taskHref=TasksResource.getTaskInfoPath(request, taskInfo);
                 for(final ParameterInfo jobConfigParameterInfo : jobConfigParams.getParams()) {
-                    JSONObject jsonObj=RunTaskServlet.initParametersJSON(request, taskInfo, jobConfigParameterInfo);
+                    final JSONObject jsonObj=RunTaskServlet.initParametersJSON(taskHref, jobConfigParameterInfo);
                     parametersArray.put(jsonObj);
                 }
             }
@@ -995,23 +996,24 @@ public class RunTaskServlet extends HttpServlet
 
     private JSONArray getParameterList(final HttpServletRequest request, final TaskInfo taskInfo)
     {
+        final String taskHref=TasksResource.getTaskInfoPath(request, taskInfo);
         final ParameterInfo[] pArray=taskInfo.getParameterInfoArray();
         final JSONArray parametersObject = new JSONArray();
         for(final ParameterInfo pinfo : pArray) {
-            final ParametersJSON parameter = initParametersJSON(request, taskInfo, pinfo);
+            final ParametersJSON parameter = initParametersJSON(taskHref, pinfo);
             parametersObject.put(parameter);
         }
         return parametersObject;
     }
 
-    public static ParametersJSON initParametersJSON(final HttpServletRequest request, final TaskInfo taskInfo, final ParameterInfo pinfo) {
+    public static ParametersJSON initParametersJSON(final String taskHref, final ParameterInfo pinfo) {
         // don't initialize the drop-down menu; instead wait for the web client to make a callback
         final boolean initDropdown=false;
         final ParametersJSON parameter = new ParametersJSON(pinfo);
         parameter.addNumValues(pinfo);
         parameter.addRangeInfo(pinfo);
         parameter.addGroupInfo(pinfo);
-        parameter.initChoice(request, taskInfo, pinfo, initDropdown);
+        parameter.addChoiceInfo(taskHref, pinfo, initDropdown);
         return parameter;
     }
 

--- a/src/org/genepattern/server/webapp/rest/api/v1/task/TasksResource.java
+++ b/src/org/genepattern/server/webapp/rest/api/v1/task/TasksResource.java
@@ -151,21 +151,6 @@ public class TasksResource {
     }
 
     /**
-     * Get the relative path, relative to the root REST API end point, to GET the choiceInfo for the given parameter for the given task.
-     *
-     * @param taskInfo
-     * @param pname
-     * @return
-     */
-    public static String getChoiceInfoPath(final HttpServletRequest request, final TaskInfo taskInfo, final String pname) {
-        // at the moment, (circa GP 3.7.0), the task LSID and the parameter name will be valid URI path components
-        // if this ever changes we should encode them
-        //String path = URI_PATH + "/" + UrlUtil.encodeURIcomponent( taskInfo.getLsid() ) + "/" + UrlUtil.encodeURIcomponent( pname ) + "/choiceInfo.json";
-        String path = getTaskInfoPath(request, taskInfo) + "/" + pname  + "/choiceInfo.json";
-        return path;
-    }
-
-    /**
      * Get the JSON representation for the list of one or more license agreements which the current user must agree to
      * before they can run the given module.
      *
@@ -643,11 +628,12 @@ public class TasksResource {
         return createTaskObject(taskInfo, request, includeProperties, includeChildren, includeEula, false, includeParamGroups, includeMemorySettings);
     }
 
-    public static JSONObject createTaskObject(TaskInfo taskInfo, HttpServletRequest request, boolean includeProperties, boolean includeChildren, boolean includeEula, boolean includeSupportFiles, boolean includeParamGroups, boolean includeMemorySettings) throws Exception {
+    public static JSONObject createTaskObject(final TaskInfo taskInfo, final HttpServletRequest request, final boolean includeProperties, final boolean includeChildren, final boolean includeEula, final boolean includeSupportFiles, final boolean includeParamGroups, final boolean includeMemorySettings) 
+    throws Exception {
         final GpContext taskContext = Util.getTaskContext(request, taskInfo.getLsid());
         final JSONObject jsonObj=new JSONObject();
-        final String href=getTaskInfoPath(request, taskInfo);
-        jsonObj.put("href", href);
+        final String taskHref=getTaskInfoPath(request, taskInfo);
+        jsonObj.put("href", taskHref);
         jsonObj.put("name", taskInfo.getName());
         try {
             final LSID lsid=new LSID(taskInfo.getLsid());
@@ -743,33 +729,7 @@ public class TasksResource {
 
         JSONArray paramsJson=new JSONArray();
         for(ParameterInfo pinfo : taskInfo.getParameterInfoArray()) {
-            final JSONObject attributesJson = new JSONObject();
-            for(final Object key : pinfo.getAttributes().keySet()) {
-                final Object value = pinfo.getAttributes().get(key);
-                if (value != null) {
-                    attributesJson.put(key.toString(), value.toString());
-                }
-            }
-            final JSONObject attrObj = new JSONObject();
-            attrObj.put("attributes", attributesJson);
-            attrObj.put("description", pinfo.getDescription());
-
-            // Handle static choice parameters
-            if (pinfo.getChoices() != null && pinfo.getChoices().size() > 0) {
-                ChoiceInfo choices = ChoiceInfoHelper.initChoiceInfo(pinfo);
-                attrObj.put("choiceInfo", ChoiceInfoHelper.initChoiceInfoJson(request, taskInfo, choices));
-            }
-
-            // Handle dynamic choice parameters
-            if (pinfo.getAttributes().containsKey("choiceDir")) {
-                ParameterInfoRecord pinfoRecord = new ParameterInfoRecord(pinfo);
-                ChoiceInfoParser parser = ChoiceInfo.getChoiceInfoParser(taskContext);
-                ChoiceInfo choices = parser.initChoiceInfo(pinfoRecord.getFormal());
-                attrObj.put("choiceInfo", ChoiceInfoHelper.initChoiceInfoJson(request, taskInfo, choices));
-            }
-
-            final JSONObject paramJson = new JSONObject();
-            paramJson.put(pinfo.getName(), attrObj);
+            final JSONObject paramJson = initParamJson(taskHref, taskContext, pinfo);
             paramsJson.put(paramJson);
         }
         jsonObj.put("params", paramsJson);
@@ -801,7 +761,8 @@ public class TasksResource {
 
                 final JSONArray jobOptionsParams=new JSONArray();
                 for(final ParameterInfo jobConfigParameterInfo : jobConfigParams.getParams()) {
-                    final JSONObject jobOption = RunTaskServlet.initParametersJSON(request, taskInfo, jobConfigParameterInfo);
+                    // TODO: change to newer REST API representation
+                    final JSONObject jobOption = RunTaskServlet.initParametersJSON(taskHref, jobConfigParameterInfo);
                     jobOptionsParams.put(jobOption);
                 }
                 configObj.put("job.inputParams", jobOptionsParams);
@@ -811,6 +772,39 @@ public class TasksResource {
         }
 
         return jsonObj;
+    }
+
+    private static JSONObject initParamJson(final String taskHref, final GpContext taskContext, final ParameterInfo pinfo) throws JSONException {
+        final JSONObject attributesJson = new JSONObject();
+        for(final Object key : pinfo.getAttributes().keySet()) {
+            final Object value = pinfo.getAttributes().get(key);
+            if (value != null) {
+                attributesJson.put(key.toString(), value.toString());
+            }
+        }
+        final JSONObject attrObj = new JSONObject();
+        attrObj.put("attributes", attributesJson);
+        attrObj.put("description", pinfo.getDescription());
+
+        // Handle static choice parameters
+        if (pinfo.getChoices() != null && pinfo.getChoices().size() > 0) {
+            final ChoiceInfo choices = ChoiceInfoHelper.initChoiceInfo(pinfo);
+            final JSONObject choiceInfoObj=ChoiceInfoHelper.initChoiceInfoJson(taskHref, choices);
+            attrObj.put("choiceInfo", choiceInfoObj);
+        }
+
+        // Handle dynamic choice parameters
+        if (pinfo.getAttributes().containsKey("choiceDir")) {
+            final ParameterInfoRecord pinfoRecord = new ParameterInfoRecord(pinfo);
+            final ChoiceInfoParser parser = ChoiceInfo.getChoiceInfoParser(taskContext);
+            final ChoiceInfo choices = parser.initChoiceInfo(pinfoRecord.getFormal());
+            final JSONObject choiceInfoObj=ChoiceInfoHelper.initChoiceInfoJson(taskHref, choices);
+            attrObj.put("choiceInfo", choiceInfoObj);
+        }
+
+        final JSONObject paramJson = new JSONObject();
+        paramJson.put(pinfo.getName(), attrObj);
+        return paramJson;
     }
 
     public static void applyJobSubmission(final JSONArray params, JobSubmission js) throws JSONException {
@@ -924,7 +918,8 @@ public class TasksResource {
         ChoiceInfo choiceInfo=parser.initChoiceInfo(pinfoRecord.getFormal());
 
         try {
-            final JSONObject choiceInfoJson=ChoiceInfoHelper.initChoiceInfoJson(request, taskContext.getTaskInfo(), choiceInfo);
+            final String taskHref=TasksResource.getTaskInfoPath(request, taskContext.getTaskInfo());
+            final JSONObject choiceInfoJson=ChoiceInfoHelper.initChoiceInfoJson(taskHref, choiceInfo);
             final String choiceInfoStr=choiceInfoJson.toString();
 
             //return the JSON representation of the job

--- a/src/org/genepattern/server/webapp/rest/api/v1/task/TasksResource.java
+++ b/src/org/genepattern/server/webapp/rest/api/v1/task/TasksResource.java
@@ -42,7 +42,6 @@ import org.genepattern.server.job.input.configparam.JobConfigParams;
 import org.genepattern.server.rest.ParameterInfoRecord;
 import org.genepattern.server.tags.TagManager;
 import org.genepattern.server.tags.TagManager.Tag;
-import org.genepattern.server.webapp.rest.RunTaskServlet;
 import org.genepattern.server.webapp.rest.api.v1.Util;
 import org.genepattern.server.webapp.rest.api.v1.suite.SuiteResource;
 import org.genepattern.server.webservice.server.dao.AdminDAO;
@@ -761,8 +760,7 @@ public class TasksResource {
 
                 final JSONArray jobOptionsParams=new JSONArray();
                 for(final ParameterInfo jobConfigParameterInfo : jobConfigParams.getParams()) {
-                    // TODO: change to newer REST API representation
-                    final JSONObject jobOption = RunTaskServlet.initParametersJSON(taskHref, jobConfigParameterInfo);
+                    final JSONObject jobOption = initParamJson(taskHref, taskContext, jobConfigParameterInfo);
                     jobOptionsParams.put(jobOption);
                 }
                 configObj.put("job.inputParams", jobOptionsParams);

--- a/test/src/org/genepattern/server/job/input/choice/TestChoiceInfoToJson.java
+++ b/test/src/org/genepattern/server/job/input/choice/TestChoiceInfoToJson.java
@@ -3,15 +3,16 @@
  *******************************************************************************/
 package org.genepattern.server.job.input.choice;
 
-import javax.servlet.http.HttpServletRequest;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import org.genepattern.webservice.TaskInfo;
+import org.genepattern.junitutil.Demo;
+import org.genepattern.server.webapp.rest.api.v1.task.TasksResource;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 /**
  * junit tests for initializing the JSON representation for a drop-down menu for a module input parameter.
@@ -24,28 +25,27 @@ import org.mockito.Mockito;
  *
  */
 public class TestChoiceInfoToJson {
-    private String choiceDir="ftp://gpftp.broadinstitute.org/example_data/gpservertest/DemoFileDropdown/input.file/";
-    HttpServletRequest request=null;
-    TaskInfo taskInfo=null;
-    ChoiceInfo choiceInfo=Mockito.mock(ChoiceInfo.class);
+    ChoiceInfo choiceInfo=mock(ChoiceInfo.class);
 
-    @Before
-    public void setUp() {
-    }
-    
     @Test
     public void nullChoiceInfo()  throws JSONException {
-        
-        JSONObject jsonObj = ChoiceInfoHelper.initChoiceInfoJson(request, taskInfo, choiceInfo);
-        Assert.assertNotNull(jsonObj);
+        final String href="";
+        JSONObject jsonObj = ChoiceInfoHelper.initChoiceInfoJson(href, choiceInfo);
+        assertNotNull(jsonObj);
     }
     
     @Test
     public void dynamicDropDown() throws JSONException {
-        Mockito.when(choiceInfo.getChoiceDir()).thenReturn(choiceDir);
-        JSONObject jsonObj = ChoiceInfoHelper.initChoiceInfoJson(request, taskInfo, choiceInfo);
-        Assert.assertEquals("choiceDir", choiceDir, 
-                jsonObj.getString("choiceDir"));
-        
+        final String lsid=Demo.cleLsid;
+        final String pname="my.parameter";
+        final String choiceDir="ftp://gpftp.broadinstitute.org/example_data/gpservertest/DemoFileDropdown/input.file/";
+        final String baseHref="http://127.0.0.1:8080/gp";
+        final String taskHref=baseHref + "/rest/"+TasksResource.URI_PATH+"/"+lsid;
+        when(choiceInfo.getChoiceDir()).thenReturn(choiceDir);
+        when(choiceInfo.getParamName()).thenReturn(pname);
+        final JSONObject jsonObj = ChoiceInfoHelper.initChoiceInfoJson(taskHref, choiceInfo);
+        final String expectedHref=taskHref+"/"+pname+"/choiceInfo.json";
+       assertEquals("href", expectedHref, jsonObj.getString("href"));
+        assertEquals("choiceDir", choiceDir, jsonObj.getString("choiceDir"));
     }
 }


### PR DESCRIPTION
Update the REST '/tasks' endpoint so that the job.inputParams are in the same format as the other params. Pull changes from GP_7403_part2 into develop.
