### PR TITLE
configuration params for Job Object Cache, GP-7141

### DIFF
--- a/resources/config_default.yaml
+++ b/resources/config_default.yaml
@@ -252,6 +252,7 @@ default.properties:
     # 
     jobObjectCache.enabled: false
     jobObjectCache.maximumSize: 10000
+    jobObjectCache.expireAfterWriteDays: 10
     
     ##############################################################
     # Job Runner API defaults

--- a/resources/config_default.yaml
+++ b/resources/config_default.yaml
@@ -246,6 +246,14 @@ default.properties:
     org.genepattern.server.cm.CategoryManager.checkCustomCategories: true
 
     ##############################################################
+    # (experimental) JobObjectCache
+    #   cache job details in JSON format, to speed up page load
+    #   performance on the Job Summary page
+    # 
+    jobObjectCache.enabled: false
+    jobObjectCache.maximumSize: 10000
+    
+    ##############################################################
     # Job Runner API defaults
     #
     # job.cpuCount

--- a/resources/config_example.yaml
+++ b/resources/config_example.yaml
@@ -275,6 +275,14 @@ default.properties:
     # genomeSpaceAutoCreate: false
     
     ##############################################################
+    # (experimental) JobObjectCache
+    #   cache job details in JSON format, to speed up page load
+    #   performance on the Job Summary page
+    # 
+    jobObjectCache.enabled: false
+    jobObjectCache.maximumSize: 10000
+    
+    ##############################################################
     # Job Runner API defaults
     #
     # job.cpuCount

--- a/resources/config_example.yaml
+++ b/resources/config_example.yaml
@@ -281,6 +281,7 @@ default.properties:
     # 
     jobObjectCache.enabled: false
     jobObjectCache.maximumSize: 10000
+    jobObjectCache.expireAfterWriteDays: 10
     
     ##############################################################
     # Job Runner API defaults

--- a/src/org/genepattern/server/webapp/rest/api/v1/job/GetPipelineJobLegacy.java
+++ b/src/org/genepattern/server/webapp/rest/api/v1/job/GetPipelineJobLegacy.java
@@ -154,9 +154,10 @@ public class GetPipelineJobLegacy implements GetJob {
     
     protected final LoadingCache<String, JSONObject> initJobCache(final GpConfig gpConfig, final GpContext serverContext) {
         final long maxSize=JobObjectCache.getMaximumSize(gpConfig, serverContext);
+        final long days=JobObjectCache.getExpireAfterWriteDays(gpConfig, serverContext);
         return CacheBuilder.newBuilder()
             .maximumSize(maxSize)
-            .expireAfterWrite(10, TimeUnit.DAYS)
+            .expireAfterWrite(days, TimeUnit.DAYS)
             .build(
                 new CacheLoader<String, JSONObject>() {
                     public JSONObject load(String key) throws Exception {

--- a/src/org/genepattern/server/webapp/rest/api/v1/job/GetPipelineJobLegacy.java
+++ b/src/org/genepattern/server/webapp/rest/api/v1/job/GetPipelineJobLegacy.java
@@ -5,7 +5,10 @@ package org.genepattern.server.webapp.rest.api.v1.job;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.log4j.Logger;
 import org.genepattern.server.JobInfoManager;
@@ -25,12 +28,17 @@ import org.genepattern.server.job.tag.JobTag;
 import org.genepattern.server.job.tag.JobTagManager;
 import org.genepattern.server.webapp.rest.api.v1.DateUtil;
 import org.genepattern.webservice.JobInfo;
+import org.genepattern.webservice.JobInfoUtil;
 import org.genepattern.webservice.ParameterInfo;
 import org.genepattern.webservice.TaskInfo;
 import org.genepattern.webservice.TaskInfoCache;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 
 public class GetPipelineJobLegacy implements GetJob {
     private static final Logger log = Logger.getLogger(GetPipelineJobLegacy.class);
@@ -115,11 +123,11 @@ public class GetPipelineJobLegacy implements GetJob {
         return getJob(userContext, jobInfo, includeChildren, includeOutputFiles, includePermissions, includeComments, includeTags);
     }
 
-    public JSONObject getJob(final GpContext userContext, final JobInfo jobInfo, final boolean includeChildren,
-                             final boolean includeOutputFiles, final boolean includePermissions,
-                             final boolean includeComments, final boolean includeTags) throws GetJobException {
-        //manually create a JSONObject representing the job
-        final JSONObject job;
+    protected JSONObject _getJob(final GpContext userContext, final JobInfo jobInfo, final boolean includeChildren,
+            final boolean includeOutputFiles,
+            final boolean includeComments, final boolean includeTags) throws GetJobException {
+        
+        JSONObject job=null;
         if (!includeChildren) {
             job = initJsonObject(gpUrl, jobInfo, includeOutputFiles, includeComments, includeTags);
         }
@@ -136,19 +144,74 @@ public class GetPipelineJobLegacy implements GetJob {
                 throw new GetJobException(errorMessage + ": "+t.getLocalizedMessage());
             }
         }
-        if (includePermissions && job!=null) {
-            //only include permissions for the top-level job
-            try {
-            JSONObject permissions=initPermissionsFromJob(userContext, jobInfo);
-            if (permissions!=null) {
-                job.put("permissions", permissions);
+       return job;
+    }
+    
+    protected static LoadingCache<String, JSONObject> jobCache;
+    protected static final HashMap<String, Object[]> paramMap = new HashMap<String, Object[]>();
+    
+    public JSONObject getJob(final GpContext userContext, final JobInfo jobInfo, final boolean includeChildren,
+                             final boolean includeOutputFiles, final boolean includePermissions,
+                             final boolean includeComments, final boolean includeTags) throws GetJobException {
+        //manually create a JSONObject representing the job
+        
+        final String composite_key = ""+jobInfo.getJobNumber() + includeChildren + includeOutputFiles + includeComments + includeTags;
+        Object[] params = new Object[6];
+        params[0]=jobInfo;
+        params[1]=includeChildren;
+        params[2]=includeOutputFiles;
+        params[3]=includeComments;
+        params[4]=includeTags;
+        params[5]=userContext;
+        paramMap.put(composite_key, params);
+        // ***** the paramMap is a hack to get all this stuff up via the composite key even though it must be final
+        if (jobCache == null){
+            jobCache = CacheBuilder.newBuilder()
+                .maximumSize(10000)
+                .expireAfterWrite(10, TimeUnit.DAYS)
+                 .build(
+                    new CacheLoader<String, JSONObject>() {
+                      public JSONObject load(String key) throws Exception {
+                          Object[] params = paramMap.get(key);
+                          JobInfo ji = (JobInfo)params[0];
+                          Boolean inclChildren = (Boolean)params[1];
+                          Boolean inclOutputFiles = (Boolean)params[2];
+                          Boolean inclComments = (Boolean)params[3];
+                          Boolean inclTags = (Boolean)params[3];
+                          GpContext uc = (GpContext)params[5];
+                          if (log.isDebugEnabled()) {
+                              log.debug("--->>>  ADDING TO CACHE "+ ji.getJobNumber() + "  " + ji.getStatus() + "  " + key);
+                          }
+                         return _getJob(uc, ji, inclChildren, inclOutputFiles, inclComments, inclTags);
+                      }
+                    });
+        }
+        JSONObject job = null;
+        try {
+            if (JobInfoUtil.isFinished(jobInfo)) {
+                job=jobCache.get(composite_key);                 
+            } else {
+                // skip the cache if not finished, don't use the constructor since we don't want it cached
+                job = _getJob(userContext, jobInfo, includeChildren, includeOutputFiles, includeComments, includeTags);
             }
-            }
-            catch (Throwable t) {
-                final String errorMessage="Error initializing permissions for jobId="+jobInfo.getJobNumber();
-                log.error(errorMessage, t);
-                throw new GetJobException(errorMessage + ": "+t.getLocalizedMessage());
-            }
+            if (includePermissions && job!=null) {
+                //only include permissions for the top-level job
+                try {
+                    JSONObject permissions=initPermissionsFromJob(userContext, jobInfo);
+                    if (permissions!=null) {
+                        job.put("permissions", permissions);
+                    }
+                }
+                catch (Throwable t) {
+                    final String errorMessage="Error initializing permissions for jobId="+jobInfo.getJobNumber();
+                    log.error(errorMessage, t);
+                    throw new GetJobException(errorMessage + ": "+t.getLocalizedMessage());
+                }
+            } 
+        } catch (ExecutionException e){
+            final String errorMessage="Error initializing permissions for jobId="+jobInfo.getJobNumber();
+            log.error(errorMessage, e);
+            throw new GetJobException(errorMessage);
         }
         return job;
     }
@@ -158,6 +221,7 @@ public class GetPipelineJobLegacy implements GetJob {
         try {
             // constructor starts a new DB transaction
             final PermissionsHelper ph=new PermissionsHelper(
+                    HibernateUtil.instance(),
                     userContext.isAdmin(), //final boolean _isAdmin, 
                     userContext.getUserId(), // final String _userId, 
                     jobInfo.getJobNumber(), // final int _jobNo, 

--- a/src/org/genepattern/server/webapp/rest/api/v1/job/JobObjectCache.java
+++ b/src/org/genepattern/server/webapp/rest/api/v1/job/JobObjectCache.java
@@ -1,0 +1,35 @@
+package org.genepattern.server.webapp.rest.api.v1.job;
+
+
+import org.genepattern.server.config.GpConfig;
+import org.genepattern.server.config.GpContext;
+
+/**
+ * A cache of job objects (in json format) to be returned by the REST API.
+ * 
+ * Configuration options in the config_custom.yaml file:
+ * <pre>
+   # set a default value
+   jobCache.maximumSize: "10000"
+   
+   # to disable the cache, set the max size to 0
+   jobCache.maximumSize: "0"
+ * </pre>
+ * 
+ * @author pcarr
+ */
+public class JobObjectCache {
+    public static final String PROP_ENABLED="jobObjectCache.enabled";
+    public static final String PROP_MAX_SIZE="jobObjectCache.maximumSize";
+    public static final String PROP_EXPIRE_AFTER_WRITE_DAYS="jobObjectCache.expireAfterWriteDays";
+    
+    public static boolean isEnabled(final GpConfig gpConfig, final GpContext serverContext) {
+        boolean enabled = gpConfig.getGPBooleanProperty(serverContext, PROP_ENABLED, false);
+        return enabled;
+    }
+    
+    public static long getMaximumSize(final GpConfig gpConfig, final GpContext serverContext) {
+        // default is a cache of size of 10,000 records
+        return gpConfig.getGPLongProperty(serverContext, PROP_MAX_SIZE, 10000L);
+    }
+}

--- a/src/org/genepattern/server/webapp/rest/api/v1/job/JobObjectCache.java
+++ b/src/org/genepattern/server/webapp/rest/api/v1/job/JobObjectCache.java
@@ -32,4 +32,9 @@ public class JobObjectCache {
         // default is a cache of size of 10,000 records
         return gpConfig.getGPLongProperty(serverContext, PROP_MAX_SIZE, 10000L);
     }
+    
+    public static long getExpireAfterWriteDays(final GpConfig gpConfig, final GpContext serverContext) {
+        // dedfault is 10 days
+        return gpConfig.getGPLongProperty(serverContext, PROP_EXPIRE_AFTER_WRITE_DAYS, 10L);        
+    }
 }

--- a/src/org/genepattern/server/webapp/rest/api/v1/job/JobObjectCache.java
+++ b/src/org/genepattern/server/webapp/rest/api/v1/job/JobObjectCache.java
@@ -9,11 +9,12 @@ import org.genepattern.server.config.GpContext;
  * 
  * Configuration options in the config_custom.yaml file:
  * <pre>
-   # set a default value
-   jobCache.maximumSize: "10000"
-   
-   # to disable the cache, set the max size to 0
-   jobCache.maximumSize: "0"
+   # the max size of the cache, corresponds to number of objects
+   jobObjectCache.maximumSize: "10000"
+   # the number of days to keep the records in the cache
+   jobObjectCache.expireAfterWriteDays: 10
+   # to disable the cache
+   jobObjectCache.enabled: false
  * </pre>
  * 
  * @author pcarr
@@ -24,17 +25,18 @@ public class JobObjectCache {
     public static final String PROP_EXPIRE_AFTER_WRITE_DAYS="jobObjectCache.expireAfterWriteDays";
     
     public static boolean isEnabled(final GpConfig gpConfig, final GpContext serverContext) {
+        // default is false
         boolean enabled = gpConfig.getGPBooleanProperty(serverContext, PROP_ENABLED, false);
         return enabled;
     }
     
     public static long getMaximumSize(final GpConfig gpConfig, final GpContext serverContext) {
-        // default is a cache of size of 10,000 records
+        // default is 10,000 records
         return gpConfig.getGPLongProperty(serverContext, PROP_MAX_SIZE, 10000L);
     }
     
     public static long getExpireAfterWriteDays(final GpConfig gpConfig, final GpContext serverContext) {
-        // dedfault is 10 days
+        // default is 10 days
         return gpConfig.getGPLongProperty(serverContext, PROP_EXPIRE_AFTER_WRITE_DAYS, 10L);        
     }
 }


### PR DESCRIPTION
(Experimental) Add configuration options to enable/disable/customize the cache of job objects

* jobObjectCache.enabled: true
* jobObjectCache.maximumSize: 10000
* jobObjectCache.expireAfterWriteDays: 10
